### PR TITLE
Updated tests. Fixed pricing found by TestPriceInfo, now passing

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -125,6 +125,11 @@ func (n *LivepeerNode) SetBasePrice(b_eth_addr string, price *big.Rat) {
 	addr := strings.ToLower(b_eth_addr)
 	n.mu.Lock()
 	defer n.mu.Unlock()
+
+	if n.priceInfo == nil {
+		n.priceInfo = make(map[string]*big.Rat)
+	}
+
 	n.priceInfo[addr] = price
 }
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -126,10 +126,6 @@ func (n *LivepeerNode) SetBasePrice(b_eth_addr string, price *big.Rat) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	if n.priceInfo == nil {
-		n.priceInfo = make(map[string]*big.Rat)
-	}
-
 	n.priceInfo[addr] = price
 }
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -287,9 +287,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address) (*big.Rat, error) 
 	basePrice := orch.node.GetBasePrice(sender.String())
 
 	if basePrice == nil {
-		defPrice := orch.node.GetBasePrice("default")
-		orch.node.SetBasePrice(sender.String(), defPrice)
-		basePrice = defPrice
+		basePrice = orch.node.GetBasePrice("default")
 	}
 	glog.Infof("Price of %v gwei sent to broadcaster %v", basePrice.RatString(), sender.String())
 

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -203,7 +203,7 @@ func TestGetStatus(t *testing.T) {
 	req.Nil(err)
 	// expected := fmt.Sprintf(`{"Manifests":{},"InternalManifests":{},"StreamInfo":{},"OrchestratorPool":[],"Version":"undefined","GolangRuntimeVersion":"%s","GOArch":"%s","GOOS":"%s","RegisteredTranscodersNumber":1,"RegisteredTranscoders":[{"Address":"TestAddress","Capacity":5}],"LocalTranscoding":false}`,
 	// 	runtime.Version(), runtime.GOARCH, runtime.GOOS)
-	expected := fmt.Sprintf(`{"Manifests":{},"InternalManifests":{},"StreamInfo":{},"OrchestratorPool":[],"OrchestratorPoolInfos":null,"Version":"undefined","GolangRuntimeVersion":"%s","GOArch":"%s","GOOS":"%s","RegisteredTranscodersNumber":1,"RegisteredTranscoders":[{"Address":"TestAddress","Capacity":5}],"LocalTranscoding":false}`,
+	expected := fmt.Sprintf(`{"Manifests":{},"InternalManifests":{},"StreamInfo":{},"OrchestratorPool":[],"OrchestratorPoolInfos":null,"Version":"undefined","GolangRuntimeVersion":"%s","GOArch":"%s","GOOS":"%s","RegisteredTranscodersNumber":1,"RegisteredTranscoders":[{"Address":"TestAddress","Capacity":5}],"LocalTranscoding":false,"BroadcasterPrices":{},"NodeType":"transcoder"}`,
 		runtime.Version(), runtime.GOARCH, runtime.GOOS)
 	assert.Equal(expected, string(body))
 }

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -112,7 +112,9 @@ func TestOrchestratorInfoHandler_TranscoderError(t *testing.T) {
 func TestOrchestratorInfoHandler_Success(t *testing.T) {
 	assert := assert.New(t)
 
-	s := &LivepeerServer{LivepeerNode: &core.LivepeerNode{}}
+	n, _ := core.NewLivepeerNode(nil, "", nil)
+	s := &LivepeerServer{LivepeerNode: n}
+
 	price := big.NewRat(1, 2)
 	s.LivepeerNode.SetBasePrice("default", price)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixed issues that blocked tests from passing

**Specific updates (required)**
Resolved nil map `LivepeerNode.priceInfo` when running `TestOrchestratorInfoHandler_Success`
Resolved 'default' GetBasePrice issue found by `TestPriceInfo`.
Updated `cliserver_test.go` expected format to include new NodeStatus type definition

**How did you test each of these updates (required)**
Tested `-pricePerBroadcaster` with and without matching broadcaster ETH address
Tested default 'BasePrice' using -pricePerPixel without -pricePerBroadcaster

**Does this pull request close any open issues?**
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
